### PR TITLE
this will fix an issue that has ocurred during the initial start of the

### DIFF
--- a/scripts/docker-cmd.sh
+++ b/scripts/docker-cmd.sh
@@ -4,29 +4,10 @@ set -euo pipefail
 
 # fancy output
 green='\e[0;32m'
-red='\e[0;31m'
 NC='\e[0m' # No Color
 
 SPHINXINDEX_VOLUME="/var/lib/sphinxsearch/data/index/"
 SPHINXINDEX_EFS="/var/lib/sphinxsearch/data/index_efs/"
-SPHINXCONFIG="/etc/sphinxsearch/sphinx.conf"
-
-# index arrays config, filesystem and orphaned
-mapfile -t array_config < <(grep -E "^[^#]+ path" "${SPHINXCONFIG}" | awk -F"=" '{print $2}' | sed -n -e 's|^.*/||p')
-mapfile -t array_file < <(find "${SPHINXINDEX_EFS}" -maxdepth 1 -name "*.spd" | sed 's|.spd$||g' | sed -n -e 's|^.*/||p' )
-mapfile -t array_orphaned < <(comm -13 --nocheck-order <(printf '%s\n' "${array_config[@]}" | LC_ALL=C sort) <(printf '%s\n' "${array_file[@]}" | LC_ALL=C sort))
-
-# remove orphaned indexes
-echo -e "${green}looking for orphaned indexes in filesystem. ${NC}"
-for index in "${array_orphaned[@]}"; do
-    # skip empty elements
-    [[ -z ${index} ]] && continue
-    # skip .new files, we need them to sighup searchd / rotate index updates
-    if [[ ! $index == *.new ]]; then
-        echo -e "\\t${red} deleting orphaned index ${index} from filesystem. ${NC}"
-        rm -rf "${SPHINXINDEX_EFS}${index}".*
-    fi
-done
 
 # remove lock files in volume
 rm ${SPHINXINDEX_VOLUME}*.spl 2> /dev/null || :


### PR DESCRIPTION
service container in the infra vhost environment. After a scan for orphaned indexes the container (running in service mode) tried to remove orphaned indexes on EFS which was mounted read-only on the host.

in service mode (as backend for search wsgi)
the service-sphinxsearch container needs read-only access to the EFS

in maintenance mode (triggered by data deploy on geodatasync) the service-sphinxsearch container needs read-write access to the EFS

with this change the clean-up of orphaned indexes in the EFS will be done only in maintenance mode, during the sphinx index createion.

this will allow us to strictly mount the geodata efs in read-only mode on all our kubernetes or infra vhosts instances.