### PR TITLE
Even though there are going to be created a large index, this pr will

### DIFF
--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -52,8 +52,7 @@ source src_ch_swisstopo_swissboundaries3d_gemeinde_flaeche_fill : def_searchable
             , gde_name::text as label \
             , jahr as year \
             , object_id::text as feature_id \
-        FROM tlm.swissboundaries_gemeinden_hist_chsdi \
-        WHERE is_current_jahr = true
+        FROM tlm.swissboundaries_gemeinden_hist_chsdi
 }
 
 source src_ch_swisstopo_swissboundaries3d_kanton_flaeche_fill : def_searchable_features


### PR DESCRIPTION
activate all year from 1850 - 2024 to return results when querying and

not only from the most recent year.

number_of_communes * num_of_years = 2200 * (2024-1850) ~= 430K entries

https://sys-api3.dev.bgdi.ch/rest/services/ech/SearchServer?sr=2056&searchText=bern&lang=de&type=featuresearch&features=ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill&timeEnabled=true&timeStamps=2024