### PR TITLE
swissboundaries3d-gemeinden: Even though there are going to be created a large index, this pr will

### DIFF
--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -42,7 +42,7 @@ source src_ch_swisstopo_swissboundaries3d_gemeinde_flaeche_fill : def_searchable
     sql_query = \
         SELECT object_id as id \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', gde_name, object_id)) as detail \
+            , remove_accents(concat_ws(' ', gde_name, gde_nr)) as detail \
             , 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \

--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -52,8 +52,7 @@ source src_ch_swisstopo_swissboundaries3d_gemeinde_flaeche_fill : def_searchable
             , gde_name::text as label \
             , jahr as year \
             , object_id::text as feature_id \
-        FROM tlm.swissboundaries_gemeinden_hist_chsdi \
-        WHERE is_current_jahr = true
+        FROM tlm.swissboundaries_gemeinden_hist_chsdi
 }
 
 source src_ch_swisstopo_swissboundaries3d_kanton_flaeche_fill : def_searchable_features

--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -49,7 +49,7 @@ source src_ch_swisstopo_swissboundaries3d_gemeinde_flaeche_fill : def_searchable
             , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
-            , gde_name::text as label \
+            , concat_ws(' ', gde_name, jahr) as label \
             , jahr as year \
             , object_id::text as feature_id \
         FROM tlm.swissboundaries_gemeinden_hist_chsdi


### PR DESCRIPTION
activate all year from 1850 - 2024 to return results when querying and

not only from the most recent year.

number_of_communes * num_of_years = 2200 * (2024-1850) ~= 430K entries

https://sys-api3.dev.bgdi.ch/rest/services/ech/SearchServer?sr=2056&searchText=bern&lang=de&type=featuresearch&features=ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill&timeEnabled=true&timeStamps=2024