### PR TITLE
PB-82: prepare migration to k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,13 @@ FROM sphinxsearch_base as sphinxsearch_geodata
     # add geodata user, same uid/gid as the EFS owner is needed here
 RUN groupadd -r geodata -g 2500 && \
     useradd -u 2500 -r -g geodata -s /sbin/nologin --create-home geodata && \
-    # create mountpoint folders with geodata ownership
-    install -o geodata -g geodata -d /var/lib/sphinxsearch/data/index/ && \
+    # create mountpoint for Amazon EFS CSI driver
+    install -o geodata -g geodata -d /var/local/ && \
+    # create mountpoint for EFS mount in infra-vhost
+    # TODO: this mountpoint can be removed after the migration to k8s
     install -o geodata -p geodata -d /var/lib/sphinxsearch/data/index_efs/ && \
+    # create mountpoint folder for infra-vhost/k8s ebs/ssd volume
+    install -o geodata -g geodata -d /var/lib/sphinxsearch/data/index/ && \
     # change ownerships to geodata which will run the service or the maintenance scripts
     # and mount the efs folder
     chown -R geodata:geodata /var/run/sphinxsearch/ && \

--- a/scripts/docker-cmd.sh
+++ b/scripts/docker-cmd.sh
@@ -8,6 +8,15 @@ NC='\e[0m' # No Color
 
 SPHINXINDEX_VOLUME="/var/lib/sphinxsearch/data/index/"
 SPHINXINDEX_EFS="/var/lib/sphinxsearch/data/index_efs/"
+K8S_EFS="/var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/"
+
+# TODO: This switch can be removed after the migration to k8s
+# in k8s we have to use /var/local/ as mountpoint for the index files from geodata efs
+# /var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/
+if [ -d "${K8S_EFS}" ]; then
+    echo "service is running on k8s, index files have been found on ${K8S_EFS}."
+    SPHINXINDEX_EFS="${K8S_EFS}"
+fi
 
 # remove lock files in volume
 rm ${SPHINXINDEX_VOLUME}*.spl 2> /dev/null || :
@@ -18,7 +27,7 @@ rsync --update --delete -av --exclude "*.tmp.*" --stats ${SPHINXINDEX_EFS} ${SPH
 # start cron service as geodata user only if container is started in service mode (no cmd has been passed to docker run)
 # cron will sync every n minutes EFS to Docker volume and send a SIGHUP to searchd service
 service cron start || exit 1
-crontab < docker-crontab
+envsubst < docker-crontab | crontab # DBSTAGING will be read from container environment
 
 # starting the searchd service
 # will load the sphinx indexes from EFS --sync--> Volume --> into memory

--- a/scripts/docker-cmd.sh
+++ b/scripts/docker-cmd.sh
@@ -22,7 +22,7 @@ fi
 rm ${SPHINXINDEX_VOLUME}*.spl 2> /dev/null || :
 
 # sync new and updated indexes from efs to volume, ignore ongoing index creation (*.tmp.* files)
-rsync --update --delete -av --exclude "*.tmp.*" --stats ${SPHINXINDEX_EFS} ${SPHINXINDEX_VOLUME} || :
+rsync --update --delete -av --exclude "*.tmp.*" --stats "${SPHINXINDEX_EFS}" ${SPHINXINDEX_VOLUME} || :
 
 # start cron service as geodata user only if container is started in service mode (no cmd has been passed to docker run)
 # cron will sync every n minutes EFS to Docker volume and send a SIGHUP to searchd service

--- a/scripts/docker-crontab
+++ b/scripts/docker-crontab
@@ -7,6 +7,7 @@
 # *  *  *  *  *  command to be executed
 SHELL="/bin/bash"
 USER="geodata"
+DBSTAGING="${DBSTAGING}"
 
 */5 * * * * bash /index-sync-rotate.sh 1>/tmp/stdout 2>/tmp/stderr
 

--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -59,6 +59,7 @@ SPHINX_INDEXES=$(grep -E "^[^#]+ path" "${SPHINXCONFIG}" | awk -F"=" '{print $2}
 
 LOCKFILE="/tmp/$(basename "$0")"
 LOCKFD=99
+touch /tmp/last_sync_start.txt || :
 
 # PRIVATE
 _lock()             { flock -"$1" "$LOCKFD"; }
@@ -230,3 +231,4 @@ done
 
 
 echo "finished" | json_logger INFO
+touch /tmp/last_sync_finished.txt || :

--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -28,7 +28,7 @@ RSYNC_INCLUDE="/tmp/include.txt"
     # .sps stores string attribute data.
 
 # only indexes will be synced to docker volume that have been updated completely updated on EFS,
-# a completely updated index consists of the following 7 new files:
+# a completely updated index consists of the following new files:
     # .spd
     # .spe
     # .sph
@@ -43,15 +43,13 @@ json_logger() {
     self=$(readlink -f "${BASH_SOURCE[0]}")
     self=$(basename "$self")
     jq --raw-input --compact-output --monochrome-output \
-    '{ "app":
-        {
-            "time": "'"${timestamp}"'",
-            "level": "'"${log_level}"'",
-            "logger": "'"${self}"'",
-            "pidTid": "'$$'",
-            "function": "'"${FUNCNAME[0]}"'",
-            "message": .
-      }
+    '{
+        "time": "'"${timestamp}"'",
+        "level": "'"${log_level}"'",
+        "logger": "'"${self}"'",
+        "pidTid": "'$$'",
+        "function": "'"${FUNCNAME[0]}"'",
+        "message": .
     }'
 }
 


### PR DESCRIPTION
a few changes in the dockerfile and in the efs sync script are needed during the parallel operations of service-search-sphinx on infra-vhost and k8s.

on k8s we are forced to mount the efs indexes with the full path: so this will be the folder with the efs index files:
* `/var/local/geodata/service-sphinxsearch/${DBSTAGING}/index` 
 
this is due to a limitation of the aws efs csi driver which is not supporting subpaths as volumemount config. we would have to create new peristant volumes with terraform which is unreasonable for this special use-case.