### PR TITLE
PB-81: post prod deploy clean-up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ RUN groupadd -r geodata -g 2500 && \
     useradd -u 2500 -r -g geodata -s /sbin/nologin --create-home geodata && \
     # create mountpoint for Amazon EFS CSI driver
     install -o geodata -g geodata -d /var/local/ && \
-    # create mountpoint for EFS mount in infra-vhost
-    # TODO: this mountpoint can be removed after the migration to k8s
-    install -o geodata -p geodata -d /var/lib/sphinxsearch/data/index_efs/ && \
     # create mountpoint folder for infra-vhost/k8s ebs/ssd volume
     install -o geodata -g geodata -d /var/lib/sphinxsearch/data/index/ && \
     # change ownerships to geodata which will run the service or the maintenance scripts

--- a/scripts/docker-cmd.sh
+++ b/scripts/docker-cmd.sh
@@ -7,16 +7,7 @@ green='\e[0;32m'
 NC='\e[0m' # No Color
 
 SPHINXINDEX_VOLUME="/var/lib/sphinxsearch/data/index/"
-SPHINXINDEX_EFS="/var/lib/sphinxsearch/data/index_efs/"
-K8S_EFS="/var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/"
-
-# TODO: This switch can be removed after the migration to k8s
-# in k8s we have to use /var/local/ as mountpoint for the index files from geodata efs
-# /var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/
-if [ -d "${K8S_EFS}" ]; then
-    echo "service is running on k8s, index files have been found on ${K8S_EFS}."
-    SPHINXINDEX_EFS="${K8S_EFS}"
-fi
+SPHINXINDEX_EFS="/var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/"
 
 # remove lock files in volume
 rm ${SPHINXINDEX_VOLUME}*.spl 2> /dev/null || :

--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -2,8 +2,7 @@
 # executed as cronjob every 15 minutes
 # shellcheck disable=SC2068
 set -eu
-SPHINX_EFS="/var/lib/sphinxsearch/data/index_efs/"
-K8S_EFS="/var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/"
+SPHINX_EFS="/var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/"
 
 SPHINX_VOLUME="/var/lib/sphinxsearch/data/index/"
 SPHINXCONFIG="/etc/sphinxsearch/sphinx.conf"
@@ -35,7 +34,6 @@ RSYNC_INCLUDE="/tmp/include.txt"
     # .spi
     # .spp
     # .sps
-
 
 json_logger() {
     log_level=$1
@@ -78,22 +76,6 @@ exlock_now()        { _lock xn; }  # obtain an exclusive lock immediately or fai
 # avoiding running multiple instances of script.
 exlock_now || { echo "locked" | json_logger INFO; exit 1; }
 echo "start" | json_logger INFO
-
-# TODO: This switch can be removed after the migration to k8s
-# in k8s we have to use /var/local/ as mountpoint for the index files from geodata efs
-# /var/local/geodata/service-sphinxsearch/${DBSTAGING}/index/
-set_efs_source() {
-    # input:
-    #   ${SPHINX_EFS} mountpoint of efs index files
-    # 
-    # output: SPHINX_EFS
-    #   if the index files are available on the k8s mountpoint, the k8s mountpoint will be used
-    #   as efs index source
-    if [ -d "${K8S_EFS}" ]; then
-        echo "service is running on k8s, index files have been found on ${K8S_EFS}." | json_logger INFO
-        SPHINX_EFS="${K8S_EFS}"
-    fi
-}
 
 check_if_efs_index_is_ready() {
     # input:
@@ -158,8 +140,6 @@ check_if_local_index_is_ready() {
     popd
     return ${ready}
 }
-
-set_efs_source
 
 # loop through all indexes from sphinx config and sync them if the have been fully updated on efs
 for sphinx_index in ${SPHINX_INDEXES[@]}; do


### PR DESCRIPTION
these changes were needed during the parallel operation vhost/k8s

the new runtime is k8s and we dont need the infra-vhost mountpoints anymore

- [x] can be merged once the infra-vhost has been removed.