### PR TITLE
PB-1167: improve fuzzy search index configuration

### DIFF
--- a/conf/lubis.conf.part
+++ b/conf/lubis.conf.part
@@ -43,9 +43,9 @@ source src_ch_swisstopo_lubis_luftbilder_farbe : def_searchable_features_with_ye
     sql_db = lubis_${DBSTAGING}
     sql_query = \
         SELECT row_number() OVER(ORDER BY ebkey asc) as id \
-            , concat(flugdatum, ' ', bildnummer, ' (', concat_ws(', ', ort, ebkey), ')' ) as label \
+            , concat(flugdatum, ' ', feature_id, ' (', concat_ws(', ', ebkey), ')' ) as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', ebkey, ort, ebkey_old)) as detail \
+            , remove_accents(concat_ws(' ', ebkey, ebkey_old)) as detail \
             , 'ch.swisstopo.lubis-luftbilder_farbe' as layer \
             , bgdi_quadindex as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -62,9 +62,9 @@ source src_ch_swisstopo_lubis_luftbilder_schwarzweiss: def_searchable_features_w
     sql_db = lubis_${DBSTAGING}
     sql_query = \
         SELECT row_number() OVER(ORDER BY ebkey asc) as id \
-            , concat(flugdatum, ' ', bildnummer, ' (', concat_ws(', ', ort, ebkey), ')' ) as label \
+            , concat(flugdatum, ' ', feature_id, ' (', concat_ws(', ', ebkey), ')' ) as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', ebkey, ort, ebkey_old)) as detail \
+            , remove_accents(concat_ws(' ', ebkey, ebkey_old)) as detail \
             , 'ch.swisstopo.lubis-luftbilder_schwarzweiss' as layer \
             , bgdi_quadindex as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -81,9 +81,9 @@ source src_ch_swisstopo_lubis_luftbilder_infrarot: def_searchable_features_with_
     sql_db = lubis_${DBSTAGING}
     sql_query = \
         SELECT row_number() OVER(ORDER BY ebkey asc) as id \
-            , concat(flugdatum, ' ', bildnummer, ' (', concat_ws(', ', ort, ebkey, ebkey_old), ')' ) as label \
+            , concat(flugdatum, ' ', feature_id, ' (', concat_ws(', ', ebkey, ebkey_old), ')' ) as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', ebkey, ort)) as detail \
+            , remove_accents(ebkey) as detail \
             , 'ch.swisstopo.lubis-luftbilder_infrarot' as layer \
             , bgdi_quadindex as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -140,7 +140,7 @@ source src_ch_swisstopo_lubis_terrestrische_aufnahmen : def_searchable_features_
         SELECT row_number() OVER(ORDER BY inventory_number asc) as id \
             , lpad(bilder.inventory_number::text, 14, '0'::text) as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', inventory_number, image_number, station, operate_name, year, inventarnummer_old)) as detail \
+            , remove_accents(concat_ws(' ', inventory_number, station, operate_name, year, inventarnummer_old)) as detail \
             , 'ch.swisstopo.lubis-terrestrische_aufnahmen' as layer \
             , bgdi_quadindex as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \

--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -405,6 +405,7 @@ index district_metaphone : zipcode
     source = src_district
     path = /var/lib/sphinxsearch/data/index/district_metaphone
     preopen = 0
+    wordforms = /dev/null
 }
 
 index kantone_metaphone : zipcode
@@ -413,6 +414,7 @@ index kantone_metaphone : zipcode
     source = src_kantone
     path = /var/lib/sphinxsearch/data/index/kantone_metaphone
     preopen = 0
+    wordforms = /dev/null
 }
 
 index gg25_metaphone : zipcode
@@ -421,6 +423,7 @@ index gg25_metaphone : zipcode
     source = src_gg25
     path = /var/lib/sphinxsearch/data/index/gg25_metaphone
     preopen = 0
+    wordforms = /dev/null
 }
 
 index swissnames3d_metaphone : zipcode
@@ -429,6 +432,7 @@ index swissnames3d_metaphone : zipcode
     source = src_swissnames3d
     path = /var/lib/sphinxsearch/data/index/swissnames3d_metaphone
     preopen = 0
+    wordforms = /dev/null
 }
 
 index haltestellen_metaphone : zipcode
@@ -437,6 +441,7 @@ index haltestellen_metaphone : zipcode
     source = src_haltestellen
     path = /var/lib/sphinxsearch/data/index/haltestellen_metaphone
     preopen = 0
+    wordforms = /dev/null
 }
 
 index address_metaphone: zipcode
@@ -445,7 +450,7 @@ index address_metaphone: zipcode
     source = src_address
     path = /var/lib/sphinxsearch/data/index/address_metaphone
     preopen = 0
-    expand_keywords = 1
+    wordforms = /dev/null
 }
 
 # only create on demand

--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -406,6 +406,7 @@ index district_metaphone : zipcode
     path = /var/lib/sphinxsearch/data/index/district_metaphone
     preopen = 0
     wordforms = /dev/null
+    expand_keywords = 1
 }
 
 index kantone_metaphone : zipcode
@@ -415,6 +416,7 @@ index kantone_metaphone : zipcode
     path = /var/lib/sphinxsearch/data/index/kantone_metaphone
     preopen = 0
     wordforms = /dev/null
+    expand_keywords = 1
 }
 
 index gg25_metaphone : zipcode
@@ -424,6 +426,7 @@ index gg25_metaphone : zipcode
     path = /var/lib/sphinxsearch/data/index/gg25_metaphone
     preopen = 0
     wordforms = /dev/null
+    expand_keywords = 1
 }
 
 index swissnames3d_metaphone : zipcode
@@ -433,6 +436,7 @@ index swissnames3d_metaphone : zipcode
     path = /var/lib/sphinxsearch/data/index/swissnames3d_metaphone
     preopen = 0
     wordforms = /dev/null
+    expand_keywords = 1
 }
 
 index haltestellen_metaphone : zipcode
@@ -442,6 +446,7 @@ index haltestellen_metaphone : zipcode
     path = /var/lib/sphinxsearch/data/index/haltestellen_metaphone
     preopen = 0
     wordforms = /dev/null
+    expand_keywords = 1
 }
 
 index address_metaphone: zipcode
@@ -451,6 +456,7 @@ index address_metaphone: zipcode
     path = /var/lib/sphinxsearch/data/index/address_metaphone
     preopen = 0
     wordforms = /dev/null
+    expand_keywords = 1
 }
 
 # only create on demand

--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -445,6 +445,7 @@ index address_metaphone: zipcode
     source = src_address
     path = /var/lib/sphinxsearch/data/index/address_metaphone
     preopen = 0
+    expand_keywords = 1
 }
 
 # only create on demand


### PR DESCRIPTION
for fuzzy search requests we will set:
* enable_wildcards = 1
* wordforms = /dev/null

wordforms do not make sense with metaphone morphology. if wordforms are applied on a keyword, the metaphone code won't be build

with the improved fuzzy search in the wsgi app, the keywords will not be prefixed and suffixed with wildcards. we can enable wildcard expansion on all meptahone / fuzzy search indexes